### PR TITLE
Update Ruby setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ _site/
 .idea/
 codekit-config.json
 example/_site
-Gemfile.lock
 node_modules
 npm-debug.log*
 *.iml
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
-- 2.4.0
+- 2.4.1
 env:
   global:
   - secure: TOCP3WNXd7BbrQRSw6nkyGMqjzykzidKxTRm+USNEUqUgesUwED5O5TeYenkqwMEusGe72pl7Ru1bZFR2hxodjbvYBkpBttQJAbsLQXJnKNp/wdTSH8wDHomzrQ8jvWF+xf7PW16/j6uwlviq3xTYqmXdzo46398e3OTcr+1i6eJCofCApePhf8qAzOEYeCbWTQY8s4XesZbP5q6Z4cgn8TinvR+TUovdagacZoyV1A0tGuFUOA+AqJ7tmkYIlCLM3BqI2LvMhNVRBxhfzMBvscjxl1fzjRkWns6QKDmPH6ILBpt09KC/4xrMbdzwHhDu8pMYp3Lwf4Uwux4ckWxdKheYH04O7rDJ63vxL3OoOb4sInxAC/DnGHmD4J9FcB3nVFQktmEiE5MR5bRZK63mxxEfqHbIVV96pCFw8n4b1Hztle0+woFuT0P6wEI+oNuIy/qU6hhlu3S/32naW2DVoGtmO5zQ2ldcVPBHXnv58xK2e8iGG5iG7yQEt/b2p2cW9K49xm83Xe79giGhy/PNtXsJPnu+lbD4u5UqiFEqVI8DNUJcBfzkkDCJE2Hi6Wh0pRYmuFuggMREbqXQPc3Mf2z+1+CMqFQXweFzJAW/O5LItErfPvoAa6FsiVNu8SILRHPBlL+xOHvtVbcZ66Tc/aoZ3Qzr3QJCb8DBktrMKE=
-install: gem install jekyll bundler jekyll-paginate
-script: jekyll build
+install: make setup
+script: make build
 after_success:
 - bash .utility/push-site-to-master.sh

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+ruby '2.4.1'
+
+gem 'jekyll', '3.7.0'
+gem 'jekyll-paginate', '1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,68 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.0.5)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.5)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (0.9.3)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.7.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.5.1)
+      sass (~> 3.4)
+    jekyll-watch (2.0.0)
+      listen (~> 3.0)
+    kramdown (1.16.2)
+    liquid (4.0.0)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    mercenary (0.3.6)
+    pathutil (0.16.1)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.1)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (3.1.0)
+    ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
+    sass (3.5.5)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (= 3.7.0)
+  jekyll-paginate (= 1.1.0)
+
+RUBY VERSION
+   ruby 2.4.1p111
+
+BUNDLED WITH
+   1.16.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+BUNDLE := bundle
+JEKYLL := $(BUNDLE) exec jekyll
+
+setup:
+	gem install bundler \
+		--no-rdoc \
+		--no-ri
+	NOKOGIRI_USE_SYSTEM_LIBRARIES=true $(BUNDLE) install \
+		--path vendor/bundle
+
+build:
+	$(JEKYLL) build
+
+serve:
+	$(JEKYLL) serve \
+		--incremental \
+		--livereload

--- a/README.md
+++ b/README.md
@@ -1,71 +1,80 @@
+# The OpenMessaging website
+
 ## Installation
 
-```shell
-~ $ gem install jekyll
-~ $ jekyll serve
-  # => Now browse to http://localhost:4000
+In order to build the website and run it locally, you'll need to have Ruby version 2.4.1 installed. If you're using [RVM](https://rvm.io/):
+
+```bash
+$ rvm install . && rvm use .
 ```
 
-## How to Publish
-Just push your change to `source` branch, and travis will do the rest things.
+If you're using [rbenv](https://github.com/rbenv/rbenv):
+
+```bash
+$ rbenv install && rbenv local 2.4.1
+```
+
+Once you're using the correct Ruby version, you can install all dependencies:
+
+```bash
+$ make setup
+```
+
+## Running the site locally
+
+To run the site locally:
+
+```bash
+$ make serve
+```
+
+Then navigate to http://localhost:4000 to visit the site. When you make changes to the website source in `_posts` or `_docs`, the site will update automatically in your browser.
+
+## How to publish the site
+
+Just push your change to `source` branch and [Travis CI](https://travis-ci.org/) will do the rest.
 
 ## HTML Structure
-This template is based on [foundation](http://foundation.zurb.com/) framework, to understand what the "row" and "column" classes mean, please refer to the foundation [documentation](http://foundation.zurb.com/sites/docs/).
 
-```html
-<!--
+This template is based on the [ZURB Foundation](http://foundation.zurb.com/) framework. For a primer on what the `row` and `column` classes mean, please refer to the Foundation [documentation](http://foundation.zurb.com/sites/docs/).
 
-  HTML files:
+### HTML files
 
-  _layouts:
-    1. blog.html -> the blog layout file
-    2. default.html -> the default layout file
-    3. post.html -> blog post layout file
+* `_layouts`
+  1. `blog.html` --- The blog layout file
+  2. `default.html` --- The default layout file
+  3. `post.html` --- The blog post layout file
+  4. `docs.html` --- The documentation page layout file
+* `blog`
+  1. `index.html` --- The blog index page
 
-  blog:
-    1. index.html -> the blog index page
 
--->
-```
+## CSS structure
 
-## CSS Structure
-The CSS files are based on foundation framework.
+The CSS files are based on the Foundation framework.
 
-```css
-<!--
+1. `fontello.css` --- The [Fontello](https://github.com/fontello/fontello) icon font
+2. `foundation.scss` --- The Foundation framework Sass source file
+3. `style.css` --- The main style
+4. `font-awesome.css` --- The [Font Awesome](http://fontawesome.io/) icon font
 
-  CSS files:
-  1. fontello.css -> fontello icon font
-  2. foundation.scss -> foundation framework
-  3. style.css -> main style
-  4. font-awesome.css -> font awesome icon font
+## Javascript structure
 
--->
-```
+Javascript files:
 
-## Javascript Structure
-
-```js
-<!--
-
-  Javascript files:
-
-  1. app.js -> main javascript file
-  2. foundation.js -> foundation framework
-  3. jquery.appear.js -> jquery plugin
-  4. jquery.countTo.js -> jquery plugin
-  5. imagesloaded.pkgd.min.js
-  6. jquery.easing.1.3.js
-  7. jquery.sequence-min.js
-  8. jquery.validate.js
-  9. json2.js
-  10. masonry.pkgd.js
-  11. slick.min.js
-  12. jquery-2.1.0.js
-  13. jquery.url.js
-  14. modernizr.foundation.js
-  15. terrific-1.1.1.js
-  16. jquery.cookie.js
-
--->
-```
+1. `app.js` --- Main JavaScript file
+2. `foundation.js` --- Foundation framework JavaScript
+3. `jquery.appear.js` --- jQuery plugin
+4. `jquery.countTo.js` --- jQuery plugin
+5. `imagesloaded.pkgd.min.js`
+6. `jquery.easing.1.3.js`
+7. `jquery.sequence-min.js`
+8. `jquery.validate.js`
+9. `json2.js`
+10. `masonry.pkgd.js`
+11. `slick.min.js`
+12. `jquery-2.1.0.js`
+13. `jquery.url.js`
+14. `modernizr.foundation.js`
+15. `terrific-1.1.1.js`
+16. `jquery.cookie.js`

--- a/_config.yml
+++ b/_config.yml
@@ -10,12 +10,19 @@ github_username:  jekyll
 
 # Build settings
 markdown: kramdown
-
+permalink: pretty
 
 paginate: 4
 paginate_path: "blog/page:num"
 
-gems: [jekyll-paginate]
+plugins:
+- jekyll-paginate
 
 include:
-  - _internal
+- _internal
+
+defaults:
+- scope:
+    path: docs
+  values:
+    layout: docs


### PR DESCRIPTION
This PR makes the Ruby setup for the repo less brittle by tying Jekyll to a specific version (using vendored rather than global Ruby assets) and updates the CI setup and README instructions. These changes should make the website more maintainable over time.