### PR TITLE
Fix broken links

### DIFF
--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -26,8 +26,8 @@ OpenMessaging benchmarking suites are currently available for the following syst
 
 For each platform, the benchmarking suite includes easy-to-use scripts for deploying that platform on [Amazon Web Services](https://aws.amazon.com) (AWS) and then running benchmarks upon deployment. For end-to-end instructions, see platform-specific docs for:
 
-* [Apache Kafka](../benchmarks/kafka)
-* [Apache Pulsar](../benchmarks/pulsar)
+* [Apache Kafka](/docs/benchmarks/kafka)
+* [Apache Pulsar](/docs/benchmarks/pulsar)
 
 ## Benchmarking workloads
 


### PR DESCRIPTION
For some reason, these relative links don't seem to work on GitHub Pages, so I'm switching to absolute URLs instead.